### PR TITLE
Fixed a problem of deleting x2 and x3 pngs from exported uuids, it's …

### DIFF
--- a/src/service/vector_service.ts
+++ b/src/service/vector_service.ts
@@ -136,7 +136,8 @@ export async function processLocalVector(uuid: string, path: string, width: numb
 
       await execShell(` sh ${SKETCHTOOL_PROXY} export layers ${dir}/${nameSketchFile} --item=${uuid} --output=${dir} --use-id-for-name`); 
       const imagePng = await fs.createReadStream(`${dir}/${uuid}.png`);
-      await execShell(` rm ${dir}/*.png`);
+      await execShell(` rm ${dir}/${uuid}.png`);
+      await execShell(` rm ${dir}/${uuid}@*x.png`);
       return imagePng;  
     }
     /* 


### PR DESCRIPTION
Hi guys, so Bryan found a bug today about how it couldn't find an image, and the problem is that in one of the lines it would remove all pngs like this rm await execShell(` rm ${dir}/*.png`) instead of await execShell(` rm ${dir}/${uuid}.png`), the reason why I had to do it like that it's because sometimes it would export the pngs that are 2x and 3x and I thought this would be good and solve the deletion of those 2x and 3x, but from the problem Bryan had would show different behavior and would erase all pngs and make SAC to crash but, so now the two lines that I added it fixes the problem that Bryan had and we even test it together and it solved the bug
